### PR TITLE
Add support for unknown fields

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1299,17 +1299,17 @@ type UBase struct {
 type U1 struct {
 	UBase
 
-	unknownFields map[string]interface{}
+	unknownFields map[string][]byte
 }
 
-func (u1 *U1) CodecOnUnknownField(fieldName string, fieldValue interface{}) {
+func (u1 *U1) CodecOnUnknownField(fieldName string, encodedValue []byte) {
 	if u1.unknownFields == nil {
-		u1.unknownFields = make(map[string]interface{})
+		u1.unknownFields = make(map[string][]byte)
 	}
-	u1.unknownFields[fieldName] = fieldValue
+	u1.unknownFields[fieldName] = encodedValue
 }
 
-func (u1 *U1) GetUnknownFields() map[string]interface{} {
+func (u1 *U1) GetUnknownFields() map[string][]byte {
 	fmt.Printf("U1.GetUnknownFields called, returning %+v\n", u1.unknownFields)
 	return u1.unknownFields
 }
@@ -1323,16 +1323,16 @@ type U2 struct {
 	B2 bool
 	I2 int
 
-	unknownFields map[string]interface{}
+	unknownFields map[string][]byte
 }
 
 var _ UnknownFieldsHandler = (*U2)(nil)
 
-func (u2 *U2) CodecOnUnknownField(fieldName string, fieldValue interface{}) {
+func (u2 *U2) CodecOnUnknownField(fieldName string, encodedValue []byte) {
 	panic("Unexpected")
 }
 
-func (u2 *U2) GetUnknownFields() map[string]interface{} {
+func (u2 *U2) GetUnknownFields() map[string][]byte {
 	fmt.Printf("U2.GetUnknownFields called, returning %+v\n", u2.unknownFields)
 	return u2.unknownFields
 }
@@ -1357,14 +1357,14 @@ func doTestEncUnknownFields(t *testing.T, h Handle) {
 		t.Fatalf("u1.UBase=%+v != u2.UBase=%+v", u1.UBase, u2.UBase)
 	}
 
-	expectedUnknownFields := map[string]interface{}{
-		"B2": false,
-		"I2": int64(3),
-		"S2": []byte("t2"),
+	expectedUnknownFields := map[string][]byte{
+		"B2": []byte{194},
+		"I2": []byte{3},
+		"S2": []byte{162, 116, 50},
 	}
 
 	if !reflect.DeepEqual(expectedUnknownFields, u1.unknownFields) {
-		t.Fatalf("1expectedUnknownFields=%+v != u1.unknownFields=%+v",
+		t.Fatalf("expectedUnknownFields=%+v != u1.unknownFields=%+v",
 			expectedUnknownFields, u1.unknownFields)
 	}
 

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1368,9 +1368,14 @@ func doTestEncUnknownFields(t *testing.T, h Handle) {
 			expectedUnknownFields, u1.unknownFields)
 	}
 
-	err = NewEncoderBytes(&bs, h).Encode(&u1)
+	var bs2 []byte
+	err = NewEncoderBytes(&bs2, h).Encode(&u1)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(bs2, bs) {
+		t.Fatalf("bs2=%+v != bs=%+v", bs2, bs)
 	}
 
 	var u22 U2

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1298,6 +1298,12 @@ type U1 struct {
 	unknownFields map[string]interface{}
 }
 
+func (u1 *U1) CodecOnUnknownField(fieldName string) {
+	fmt.Printf("Unknown field: %s\n", fieldName)
+}
+
+var _ UnknownFieldsHandler = (*U1)(nil)
+
 type U2 struct {
 	U1
 

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1299,22 +1299,18 @@ type UBase struct {
 type U1 struct {
 	UBase
 
-	unknownFields map[string][]byte
+	ufs UnknownFieldSet
 }
 
-func (u1 *U1) CodecOnUnknownField(fieldName string, encodedValue []byte) {
-	if u1.unknownFields == nil {
-		u1.unknownFields = make(map[string][]byte)
-	}
-	u1.unknownFields[fieldName] = encodedValue
+func (u1 *U1) CodecSetUnknownFields(ufs UnknownFieldSet) {
+	u1.ufs = ufs
 }
 
-func (u1 *U1) GetUnknownFields() map[string][]byte {
-	fmt.Printf("U1.GetUnknownFields called, returning %+v\n", u1.unknownFields)
-	return u1.unknownFields
+func (u1 *U1) CodecGetUnknownFields() UnknownFieldSet {
+	return u1.ufs
 }
 
-var _ UnknownFieldsHandler = (*U1)(nil)
+var _ UnknownFieldHandler = (*U1)(nil)
 
 type U2 struct {
 	UBase
@@ -1323,22 +1319,21 @@ type U2 struct {
 	B2 bool
 	I2 int
 
-	unknownFields map[string][]byte
+	ufs UnknownFieldSet
 }
 
-var _ UnknownFieldsHandler = (*U2)(nil)
+var _ UnknownFieldHandler = (*U2)(nil)
 
-func (u2 *U2) CodecOnUnknownField(fieldName string, encodedValue []byte) {
-	panic("Unexpected")
+func (u2 *U2) CodecSetUnknownFields(ufs UnknownFieldSet) {
+	u2.ufs = ufs
 }
 
-func (u2 *U2) GetUnknownFields() map[string][]byte {
-	fmt.Printf("U2.GetUnknownFields called, returning %+v\n", u2.unknownFields)
-	return u2.unknownFields
+func (u2 *U2) CodecGetUnknownFields() UnknownFieldSet {
+	return u2.ufs
 }
 
 func doTestEncUnknownFields(t *testing.T, h Handle) {
-	u2 := U2{UBase{"t1", true, 5}, "t2", false, 3, nil}
+	u2 := U2{UBase{"t1", true, 5}, "t2", false, 3, UnknownFieldSet{}}
 
 	var bs []byte
 	var err error
@@ -1363,9 +1358,9 @@ func doTestEncUnknownFields(t *testing.T, h Handle) {
 		"S2": []byte{162, 116, 50},
 	}
 
-	if !reflect.DeepEqual(expectedUnknownFields, u1.unknownFields) {
-		t.Fatalf("expectedUnknownFields=%+v != u1.unknownFields=%+v",
-			expectedUnknownFields, u1.unknownFields)
+	if !reflect.DeepEqual(expectedUnknownFields, u1.ufs.fields) {
+		t.Fatalf("expectedUnknownFields=%+v != u1.ufs.fields=%+v",
+			expectedUnknownFields, u1.ufs.fields)
 	}
 
 	var bs2 []byte

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1309,6 +1309,11 @@ func (u1 *U1) CodecOnUnknownField(fieldName string, fieldValue interface{}) {
 	u1.unknownFields[fieldName] = fieldValue
 }
 
+func (u1 *U1) GetUnknownFields() map[string]interface{} {
+	fmt.Printf("U1.GetUnknownFields called, returning %+v\n", u1.unknownFields)
+	return u1.unknownFields
+}
+
 var _ UnknownFieldsHandler = (*U1)(nil)
 
 type U2 struct {
@@ -1319,6 +1324,17 @@ type U2 struct {
 	I2 int
 
 	unknownFields map[string]interface{}
+}
+
+var _ UnknownFieldsHandler = (*U2)(nil)
+
+func (u2 *U2) CodecOnUnknownField(fieldName string, fieldValue interface{}) {
+	panic("Unexpected")
+}
+
+func (u2 *U2) GetUnknownFields() map[string]interface{} {
+	fmt.Printf("U2.GetUnknownFields called, returning %+v\n", u2.unknownFields)
+	return u2.unknownFields
 }
 
 func doTestEncUnknownFields(t *testing.T, h Handle) {

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -736,13 +736,12 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 					}
 				} else if fti.ufh {
 					ufh := f.getValueForUnmarshalInterface(rv, fti.ufhIndir).(UnknownFieldsHandler)
-					var val interface{}
-					if !dd.TryDecodeAsNil() {
-						d.decodeValue(reflect.ValueOf(&val).Elem(), nil)
-					}
+					encodedVal := d.nextValueBytes()
+					encodedValCopy := make([]byte, len(encodedVal))
+					copy(encodedValCopy, encodedVal)
 					// TODO: Is it safe to pass in
 					// stringViews?
-					ufh.CodecOnUnknownField(rvkencname, val)
+					ufh.CodecOnUnknownField(rvkencname, encodedValCopy)
 				} else {
 					d.structFieldNotFound(-1, rvkencname)
 				}

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -736,11 +736,13 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 					}
 				} else if fti.ufh {
 					ufh := f.getValueForUnmarshalInterface(rv, fti.ufhIndir).(UnknownFieldsHandler)
+					var val interface{}
+					if !dd.TryDecodeAsNil() {
+						d.decodeValue(reflect.ValueOf(&val).Elem(), nil)
+					}
 					// TODO: Is it safe to pass in
 					// stringViews?
-					ufh.CodecOnUnknownField(rvkencname)
-					// TODO: Pass in value, too.
-					d.swallow()
+					ufh.CodecOnUnknownField(rvkencname, val)
 				} else {
 					d.structFieldNotFound(-1, rvkencname)
 				}

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -734,6 +734,13 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 					} else {
 						d.decodeValue(si.field(rv, true), nil)
 					}
+				} else if fti.ufh {
+					ufh := f.getValueForUnmarshalInterface(rv, fti.ufhIndir).(UnknownFieldsHandler)
+					// TODO: Is it safe to pass in
+					// stringViews?
+					ufh.CodecOnUnknownField(rvkencname)
+					// TODO: Pass in value, too.
+					d.swallow()
 				} else {
 					d.structFieldNotFound(-1, rvkencname)
 				}

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -21,6 +21,7 @@ const (
 var (
 	onlyMapOrArrayCanDecodeIntoStructErr = errors.New("only encoded map or array can be decoded into a struct")
 	cannotDecodeIntoNilErr               = errors.New("cannot decode into nil")
+	unknownFieldHandlerOnlyWithMapErr    = errors.New("can use UnknownFieldHandler only when decoding into a map")
 )
 
 // decReader abstracts the reading source, allowing implementations that can
@@ -706,6 +707,16 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 	dd := d.d
 	cr := d.cr
 	ctyp := dd.ContainerType()
+
+	var ufh UnknownFieldHandler
+	var ufs UnknownFieldSet
+	if fti.ufh {
+		ufh = f.getValueForUnmarshalInterface(rv, fti.ufhIndir).(UnknownFieldHandler)
+		if ctyp != valueTypeMap {
+			f.d.error(unknownFieldHandlerOnlyWithMapErr)
+		}
+	}
+
 	if ctyp == valueTypeMap {
 		containerLen := dd.ReadMapStart()
 		if containerLen == 0 {
@@ -722,7 +733,8 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 				if cr != nil {
 					cr.sendContainerState(containerMapKey)
 				}
-				rvkencname := stringView(dd.DecodeBytes(f.d.b[:], true, true))
+				nameBytes := dd.DecodeBytes(f.d.b[:], true, true)
+				rvkencname := stringView(nameBytes)
 				// rvksi := ti.getForEncName(rvkencname)
 				if cr != nil {
 					cr.sendContainerState(containerMapValue)
@@ -734,14 +746,11 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 					} else {
 						d.decodeValue(si.field(rv, true), nil)
 					}
-				} else if fti.ufh {
-					ufh := f.getValueForUnmarshalInterface(rv, fti.ufhIndir).(UnknownFieldsHandler)
-					encodedVal := d.nextValueBytes()
-					encodedValCopy := make([]byte, len(encodedVal))
-					copy(encodedValCopy, encodedVal)
-					// TODO: Is it safe to pass in
-					// stringViews?
-					ufh.CodecOnUnknownField(rvkencname, encodedValCopy)
+				} else if ufh != nil {
+					// Need to do this before calling
+					// d.nextValueBytes().
+					nameCopy := string(nameBytes)
+					ufs.add(nameCopy, d.nextValueBytes())
 				} else {
 					d.structFieldNotFound(-1, rvkencname)
 				}
@@ -752,7 +761,8 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 				if cr != nil {
 					cr.sendContainerState(containerMapKey)
 				}
-				rvkencname := stringView(dd.DecodeBytes(f.d.b[:], true, true))
+				nameBytes := dd.DecodeBytes(f.d.b[:], true, true)
+				rvkencname := stringView(nameBytes)
 				// rvksi := ti.getForEncName(rvkencname)
 				if cr != nil {
 					cr.sendContainerState(containerMapValue)
@@ -764,6 +774,11 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 					} else {
 						d.decodeValue(si.field(rv, true), nil)
 					}
+				} else if ufh != nil {
+					// Need to do this before calling
+					// d.nextValueBytes().
+					nameCopy := string(nameBytes)
+					ufs.add(nameCopy, d.nextValueBytes())
 				} else {
 					d.structFieldNotFound(-1, rvkencname)
 				}
@@ -771,6 +786,9 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 		}
 		if cr != nil {
 			cr.sendContainerState(containerMapEnd)
+		}
+		if ufh != nil {
+			ufh.CodecSetUnknownFields(ufs)
 		}
 	} else if ctyp == valueTypeArray {
 		containerLen := dd.ReadArrayStart()

--- a/codec/encode.go
+++ b/codec/encode.go
@@ -513,6 +513,12 @@ type keyValuePair struct {
 	encodedVal []byte
 }
 
+type keyValuePairSlice []keyValuePair
+
+func (p keyValuePairSlice) Len() int           { return len(p) }
+func (p keyValuePairSlice) Less(i, j int) bool { return p[i].key < p[j].key }
+func (p keyValuePairSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
 func (f *encFnInfo) kStruct(rv reflect.Value) {
 	fti := f.ti
 	e := f.e
@@ -581,6 +587,8 @@ func (f *encFnInfo) kStruct(rv reflect.Value) {
 	ee := e.e //don't dereference everytime
 
 	if toMap {
+		sort.Sort(keyValuePairSlice(fkvs[:newlen]))
+
 		ee.EncodeMapStart(newlen)
 		// asSymbols := e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0
 		asSymbols := e.h.AsSymbols == AsSymbolDefault || e.h.AsSymbols&AsSymbolStructFieldNameFlag != 0

--- a/codec/encode.go
+++ b/codec/encode.go
@@ -527,7 +527,7 @@ func (f *encFnInfo) kStruct(rv reflect.Value) {
 	toMap := !(fti.toArray || e.h.StructToArray)
 	newlen := len(fti.sfi)
 
-	var unknownFields map[string][]byte
+	var ufs UnknownFieldSet
 	// TODO: Merge unknown fields with known ones rather than just
 	// tack the unknown ones at the end.
 	if fti.ufh {
@@ -535,8 +535,8 @@ func (f *encFnInfo) kStruct(rv reflect.Value) {
 			if !toMap {
 				panic("Unknown fields supported only when toMap=true")
 			}
-			unknownFields = ufh.(UnknownFieldsHandler).GetUnknownFields()
-			newlen += len(unknownFields)
+			ufs = ufh.(UnknownFieldHandler).CodecGetUnknownFields()
+			newlen += len(ufs.fields)
 		}
 	}
 
@@ -574,10 +574,10 @@ func (f *encFnInfo) kStruct(rv reflect.Value) {
 		newlen++
 	}
 
-	for k, v := range unknownFields {
-		kv.key = k
+	for name, encodedVal := range ufs.fields {
+		kv.key = name
 		kv.encoded = true
-		kv.encodedVal = v
+		kv.encodedVal = encodedVal
 		fkvs[newlen] = kv
 		newlen++
 	}

--- a/codec/encode.go
+++ b/codec/encode.go
@@ -592,8 +592,16 @@ func (f *encFnInfo) kStruct(rv reflect.Value) {
 	if toMap {
 		if len(ufs.fields) > 0 {
 			// We have unknown fields, so we need to
-			// re-sort.
+			// re-sort. Also check for duplicate field
+			// names.
 			sort.Sort(structFieldSlice(fsfs[:newlen]))
+			for j := 1; j < newlen; j++ {
+				sfPrev := fsfs[j-1]
+				sf := fsfs[j]
+				if sf.name == sfPrev.name {
+					panic(fmt.Errorf("Duplicate field with name %q", sf.name))
+				}
+			}
 		}
 
 		ee.EncodeMapStart(newlen)

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -333,7 +333,7 @@ func (ufs *UnknownFieldSet) add(name string, encodedVal []byte) {
 	ufs.fields[name] = encodedValCopy
 }
 
-// UnknownFieldsHandler defines methods by which a value can store
+// UnknownFieldHandler defines methods by which a value can store
 // unknown fields encountered during decoding.
 type UnknownFieldHandler interface {
 	// CodecSetUnknownFields is called exactly once during
@@ -766,8 +766,8 @@ type typeInfo struct {
 	cs      bool // base type (T or *T) is a Selfer
 	csIndir int8 // number of indirections to get to Selfer type
 
-	ufh      bool // base type (T or *T) is an UnknownFieldsHandler
-	ufhIndir int8 // number of indirections to get to UnknownFieldsHandler type
+	ufh      bool // base type (T or *T) is an UnknownFieldHandler
+	ufhIndir int8 // number of indirections to get to UnknownFieldHandler type
 
 	toArray bool // whether this (struct) type should be encoded as an array
 }

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -341,7 +341,8 @@ type UnknownFieldHandler interface {
 	CodecSetUnknownFields(UnknownFieldSet)
 	// CodecGetUnknownFields is called exactly once during
 	// encoding to get the set of unknown fields to include in the
-	// encoding.
+	// encoding. Encoding must be done with the same handle type
+	// as what was used when decoding.
 	CodecGetUnknownFields() UnknownFieldSet
 }
 

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -315,6 +315,7 @@ type Selfer interface {
 // unknown fields encountered during decoding.
 type UnknownFieldsHandler interface {
 	CodecOnUnknownField(fieldName string, fieldValue interface{})
+	GetUnknownFields() map[string]interface{}
 }
 
 // MapBySlice represents a slice which should be encoded as a map in the stream.

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -312,10 +312,18 @@ type Selfer interface {
 }
 
 // An UnknownFieldSet holds information about unknown fields
-// encountered during decoding.
+// encountered during decoding. The zero value is an empty
+// set.
 type UnknownFieldSet struct {
 	// Map from field name to encoded value.
 	fields map[string][]byte
+}
+
+// DeepCopy returns a deep copy of the receiver.
+func (ufs UnknownFieldSet) DeepCopy() UnknownFieldSet {
+	// UnknownFieldSet is externally immutable, so it's okay to
+	// just return the receiver.
+	return ufs
 }
 
 func (ufs *UnknownFieldSet) add(name string, encodedVal []byte) {

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -314,7 +314,7 @@ type Selfer interface {
 // UnknownFieldsHandler defines methods by which a value can store
 // unknown fields encountered during decoding.
 type UnknownFieldsHandler interface {
-	CodecOnUnknownField(fieldName string)
+	CodecOnUnknownField(fieldName string, fieldValue interface{})
 }
 
 // MapBySlice represents a slice which should be encoded as a map in the stream.

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -314,8 +314,8 @@ type Selfer interface {
 // UnknownFieldsHandler defines methods by which a value can store
 // unknown fields encountered during decoding.
 type UnknownFieldsHandler interface {
-	CodecOnUnknownField(fieldName string, fieldValue interface{})
-	GetUnknownFields() map[string]interface{}
+	CodecOnUnknownField(fieldName string, encodedValue []byte)
+	GetUnknownFields() map[string][]byte
 }
 
 // MapBySlice represents a slice which should be encoded as a map in the stream.


### PR DESCRIPTION
Add UnknownFieldSet type and UnknownFieldHandler
interface, and use it. Currently it's only supported for
decoding/encoding into a map, and only with the same
handle.

This implementation has the nice guarantee that
unknown fields are passed through, so that encoding with
unknown fields produces the same result as if the fields
were known.

Also add test.
