### PR TITLE
Make UnknownFieldSet embeddable

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1335,6 +1335,28 @@ func doTestEncUnknownFields(t *testing.T, h Handle) {
 		t.Fatal(err)
 	}
 
+	// Decode it into a map.
+	var m map[string]interface{}
+	err = NewDecoderBytes(bs2, h).Decode(&m)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expectedM := map[string]interface{}{
+		"S":  "t1",
+		"B":  true,
+		"I":  int64(5),
+		"S2": "t2",
+		"B2": false,
+		"I2": int64(3),
+	}
+
+	// Decoded map should have all fields except for
+	// UnknownFieldSet.
+	if !reflect.DeepEqual(expectedM, m) {
+		t.Fatalf("expectedM=%+v != m=%+v", expectedM, m)
+	}
+
 	// Decode it into a U1.
 	var u1 U1
 	err = NewDecoderBytes(bs2, h).Decode(&u1)

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1299,15 +1299,7 @@ type UBase struct {
 type U1 struct {
 	UBase
 
-	ufs UnknownFieldSet
-}
-
-func (u1 *U1) CodecSetUnknownFields(ufs UnknownFieldSet) {
-	u1.ufs = ufs
-}
-
-func (u1 *U1) CodecGetUnknownFields() UnknownFieldSet {
-	return u1.ufs
+	UnknownFieldSet
 }
 
 var _ UnknownFieldHandler = (*U1)(nil)
@@ -1319,18 +1311,10 @@ type U2 struct {
 	B2 bool
 	I2 int
 
-	ufs UnknownFieldSet
+	UnknownFieldSet
 }
 
 var _ UnknownFieldHandler = (*U2)(nil)
-
-func (u2 *U2) CodecSetUnknownFields(ufs UnknownFieldSet) {
-	u2.ufs = ufs
-}
-
-func (u2 *U2) CodecGetUnknownFields() UnknownFieldSet {
-	return u2.ufs
-}
 
 func doTestEncUnknownFields(t *testing.T, h Handle) {
 	u2 := U2{
@@ -1374,8 +1358,9 @@ func doTestEncUnknownFields(t *testing.T, h Handle) {
 	}
 
 	// Decoded U1 should have the U2-only fields as unknown.
-	if !reflect.DeepEqual(expectedUfs, u1.ufs) {
-		t.Fatalf("expectedUfs=%+v != u1.ufs=%+v", expectedUfs, u1.ufs)
+	if !reflect.DeepEqual(expectedUfs, u1.UnknownFieldSet) {
+		t.Fatalf("expectedUfs=%+v != u1.UnknownFieldSet=%+v",
+			expectedUfs, u1.UnknownFieldSet)
 	}
 
 	// Encode U1.

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -316,7 +316,8 @@ type Selfer interface {
 // set.
 //
 // UnknownFieldSet implements UnknownFieldHandler, so you can just
-// embed it in a struct type that you want to preserve unknown fields.
+// embed it in a struct type and it will automatically preserve
+// unknown fields.
 type UnknownFieldSet struct {
 	// Map from field name to encoded value.
 	fields map[string][]byte

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -314,9 +314,22 @@ type Selfer interface {
 // An UnknownFieldSet holds information about unknown fields
 // encountered during decoding. The zero value is an empty
 // set.
+//
+// UnknownFieldSet implements UnknownFieldHandler, so you can just
+// embed it in a struct type that you want to preserve unknown fields.
 type UnknownFieldSet struct {
 	// Map from field name to encoded value.
 	fields map[string][]byte
+}
+
+var _ UnknownFieldHandler = (*UnknownFieldSet)(nil)
+
+func (ufs *UnknownFieldSet) CodecSetUnknownFields(other UnknownFieldSet) {
+	*ufs = other
+}
+
+func (ufs UnknownFieldSet) CodecGetUnknownFields() UnknownFieldSet {
+	return ufs
 }
 
 // DeepCopy returns a deep copy of the receiver.


### PR DESCRIPTION
This will remove boilerplate for types that just want to preserve unknown fields.
