### PR TITLE
Add unknown field handler flags

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1420,8 +1420,22 @@ func doTestEncUnknownFields(t *testing.T, h Handle) {
 		t.Fatal(err)
 	}
 
-	// Encoded U1 with unknown fields should encode into the same
-	// bytes as the U2.
+	// u1WithUnknown encoded without unknown fields should encode
+	// into the same bytes as u1.
+
+	var bs3 []byte
+	h.getBasicHandle().EncodeUnknownFields = true
+	err = NewEncoderBytes(&bs3, h).Encode(&u1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(bs3, bs1) {
+		t.Fatalf("bs3=%+v != bs1WithUnknown=%+v", bs3, bs1)
+	}
+
+	// u1WithUnknown encoded with unknown fields should encode
+	// into the same bytes as the U2.
 	if !reflect.DeepEqual(bs2, bs1WithUnknown) {
 		t.Fatalf("bs2=%+v != bs1WithUnknown=%+v", bs2, bs1WithUnknown)
 	}

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1299,7 +1299,7 @@ type UBase struct {
 type U1 struct {
 	UBase
 
-	UnknownFieldSet
+	UnknownFieldSetHandler
 }
 
 var _ UnknownFieldHandler = (*U1)(nil)
@@ -1311,7 +1311,7 @@ type U2 struct {
 	B2 bool
 	I2 int
 
-	UnknownFieldSet
+	UnknownFieldSetHandler
 }
 
 var _ UnknownFieldHandler = (*U2)(nil)
@@ -1389,16 +1389,16 @@ func doTestEncUnknownFields(t *testing.T, h Handle) {
 		},
 	}
 
-	if len(u1.UnknownFieldSet.fields) > 0 {
-		t.Fatalf("len(u1.UnknownFieldSet.fields)=%d > 0",
-			len(u1.UnknownFieldSet.fields))
+	if len(u1.CodecGetUnknownFields().fields) > 0 {
+		t.Fatalf("len(u1.CodecGetUnknownFields().fields)=%d > 0",
+			len(u1.CodecGetUnknownFields().fields))
 	}
 
 	// Decoded U1 with unknown fields should have the U2-only
 	// fields as unknown.
-	if !reflect.DeepEqual(expectedUfs, u1WithUnknown.UnknownFieldSet) {
-		t.Fatalf("expectedUfs=%+v != u1WithUnknown.UnknownFieldSet=%+v",
-			expectedUfs, u1WithUnknown.UnknownFieldSet)
+	if !reflect.DeepEqual(expectedUfs, u1WithUnknown.CodecGetUnknownFields()) {
+		t.Fatalf("expectedUfs=%+v != u1WithUnknown.CodecGetUnknownFields()=%+v",
+			expectedUfs, u1WithUnknown.CodecGetUnknownFields())
 	}
 
 	// Encode U1.

--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1403,7 +1403,9 @@ func doTestEncUnknownFields(t *testing.T, h Handle) {
 
 	// Encode U1.
 	var bs1 []byte
+	h.getBasicHandle().EncodeUnknownFields = true
 	err = NewEncoderBytes(&bs1, h).Encode(&u1WithUnknown)
+	h.getBasicHandle().EncodeUnknownFields = false
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/codec/decode.go
+++ b/codec/decode.go
@@ -114,8 +114,17 @@ type DecodeOptions struct {
 	// Instead, we provision up to MaxInitLen, fill that up, and start appending after that.
 	MaxInitLen int
 
-	// If ErrorIfNoField, return an error when decoding a map
-	// from a codec stream into a struct, and no matching struct field is found.
+	// If DecodeUnknownFields, then when decoding a map from a
+	// codec stream into a struct implementing
+	// UnknownFieldHandler, and no matching struct field is found,
+	// keep track of the unknown fields and pass them into
+	// CodecSetUnknownFields().
+	DecodeUnknownFields bool
+
+	// If ErrorIfNoField, return an error when decoding a map from
+	// a codec stream into a struct, no matching struct field is
+	// found, and either DecodeUnknownFields is not set or the
+	// struct doesn't implement UnknownFieldHandler.
 	ErrorIfNoField bool
 
 	// If ErrorIfNoArrayExpand, return an error when decoding a slice/array that cannot be expanded.
@@ -710,7 +719,7 @@ func (f *decFnInfo) kStruct(rv reflect.Value) {
 
 	var ufh UnknownFieldHandler
 	var ufs UnknownFieldSet
-	if fti.ufh {
+	if d.h.DecodeUnknownFields && fti.ufh {
 		ufh = f.getValueForUnmarshalInterface(rv, fti.ufhIndir).(UnknownFieldHandler)
 		if ctyp != valueTypeMap {
 			f.d.error(unknownFieldHandlerOnlyWithMapErr)

--- a/codec/encode.go
+++ b/codec/encode.go
@@ -134,6 +134,11 @@ type EncodeOptions struct {
 	//   AsSymbolMapStringKeys
 	//   AsSymbolMapStringKeysFlag | AsSymbolStructFieldNameFlag
 	AsSymbols AsSymbolFlag
+
+	// If EncodeUnknownFields, then when encoding a struct
+	// implementing UnknownFieldHandler, also encode the unknown
+	// fields.
+	EncodeUnknownFields bool
 }
 
 // ---------------------------------------------
@@ -533,7 +538,7 @@ func (f *encFnInfo) kStruct(rv reflect.Value) {
 	newlen := len(fti.sfi)
 
 	var ufs UnknownFieldSet
-	if fti.ufh {
+	if e.h.EncodeUnknownFields && fti.ufh {
 		if ufh, proceed := f.getValueForMarshalInterface(rv, fti.ufhIndir); proceed {
 			if !toMap {
 				panic(errors.New("can use UnknownFieldHandler only when encoding into a map"))

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -314,21 +314,9 @@ type Selfer interface {
 // An UnknownFieldSet holds information about unknown fields
 // encountered during decoding. The zero value is an empty
 // set.
-//
-// You can use reflect.DeepEquals with UnknownFieldSet, although
-// equality only makes sense with respect to UnknownFieldSets that
-// arise from decoding with the same handle, or the zero
-// UnknownFieldSet.
 type UnknownFieldSet struct {
 	// Map from field name to encoded value.
 	fields map[string][]byte
-}
-
-// DeepCopy returns a deep copy of the receiver.
-func (ufs UnknownFieldSet) DeepCopy() UnknownFieldSet {
-	// UnknownFieldSet is externally immutable, so it's okay to
-	// just return the receiver.
-	return ufs
 }
 
 func (ufs *UnknownFieldSet) add(name string, encodedVal []byte) {

--- a/codec/helper.go
+++ b/codec/helper.go
@@ -315,10 +315,6 @@ type Selfer interface {
 // encountered during decoding. The zero value is an empty
 // set.
 //
-// UnknownFieldSet implements UnknownFieldHandler, so you can just
-// embed it in a struct type and it will automatically preserve
-// unknown fields.
-//
 // You can use reflect.DeepEquals with UnknownFieldSet, although
 // equality only makes sense with respect to UnknownFieldSets that
 // arise from decoding with the same handle, or the zero
@@ -326,16 +322,6 @@ type Selfer interface {
 type UnknownFieldSet struct {
 	// Map from field name to encoded value.
 	fields map[string][]byte
-}
-
-var _ UnknownFieldHandler = (*UnknownFieldSet)(nil)
-
-func (ufs *UnknownFieldSet) CodecSetUnknownFields(other UnknownFieldSet) {
-	*ufs = other
-}
-
-func (ufs UnknownFieldSet) CodecGetUnknownFields() UnknownFieldSet {
-	return ufs
 }
 
 // DeepCopy returns a deep copy of the receiver.
@@ -373,6 +359,23 @@ type UnknownFieldHandler interface {
 	// encoding. Encoding must be done with the same handle type
 	// as what was used when decoding.
 	CodecGetUnknownFields() UnknownFieldSet
+}
+
+// UnknownFieldSetHandler is an implementation of UnknownFieldHandler
+// that uses an underlying UnknownFieldSet, so you can just embed it
+// in a struct type and it will automatically preserve unknown fields.
+type UnknownFieldSetHandler struct {
+	ufs UnknownFieldSet
+}
+
+var _ UnknownFieldHandler = (*UnknownFieldSetHandler)(nil)
+
+func (ufsh *UnknownFieldSetHandler) CodecSetUnknownFields(other UnknownFieldSet) {
+	ufsh.ufs = other
+}
+
+func (ufsh UnknownFieldSetHandler) CodecGetUnknownFields() UnknownFieldSet {
+	return ufsh.ufs
 }
 
 // MapBySlice represents a slice which should be encoded as a map in the stream.


### PR DESCRIPTION
This is useful for testing, and also maintains theoretical
backwards compatibility.

Make new type UnknownFieldSetHandler that should be
embedded instead of UnknownFieldSet directly. This
is so that any methods added to UnknownFieldSet don't
inadvertently get embedded, too.

Remove DeepCopy method.
