### PR TITLE
Fix inconsistent test failure

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -1317,6 +1317,8 @@ type U2 struct {
 var _ UnknownFieldHandler = (*U2)(nil)
 
 func doTestEncUnknownFields(t *testing.T, h Handle) {
+	testOnce.Do(testInitAll)
+
 	u2 := U2{
 		UBase: UBase{
 			S: "t1",


### PR DESCRIPTION
run testInitAll from doTestEncUnknownFields, which fixes a test
failure when test doTestEncUnknownFields is run by itself.