### PR TITLE
Revert to old int encoding behavior

### DIFF
--- a/codec/codec_test.go
+++ b/codec/codec_test.go
@@ -565,7 +565,7 @@ func testTableVerify(f testVerifyFlag, h Handle) (av []interface{}) {
 
 func testVerifyValInt(v int64, isMsgp bool) (v2 interface{}) {
 	if isMsgp {
-		if v >= 0 && v <= 127 {
+		if v >= 0 {
 			v2 = uint64(v)
 		} else {
 			v2 = int64(v)

--- a/codec/msgpack.go
+++ b/codec/msgpack.go
@@ -210,20 +210,8 @@ func (e *msgpackEncDriver) EncodeNil() {
 }
 
 func (e *msgpackEncDriver) EncodeInt(i int64) {
-	// if i >= 0 {
-	// 	e.EncodeUint(uint64(i))
-	// } else if false &&
-	if i > math.MaxInt8 {
-		if i <= math.MaxInt16 {
-			e.w.writen1(mpInt16)
-			bigenHelper{e.x[:2], e.w}.writeUint16(uint16(i))
-		} else if i <= math.MaxInt32 {
-			e.w.writen1(mpInt32)
-			bigenHelper{e.x[:4], e.w}.writeUint32(uint32(i))
-		} else {
-			e.w.writen1(mpInt64)
-			bigenHelper{e.x[:8], e.w}.writeUint64(uint64(i))
-		}
+	if i >= 0 {
+		e.EncodeUint(uint64(i))
 	} else if i >= -32 {
 		if e.h.NoFixedNum {
 			e.w.writen2(mpInt8, byte(i))


### PR DESCRIPTION
5ef60f8ad973ffb06ce2dc5a5b431127d79cdbea changed the msgpack int
encoding behavior to encode positive values of int types as signed
ints. Revert to the previous behavior of encoding them as unsigned
ints.